### PR TITLE
Skip `Update pool` workflow on `push` events

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,7 @@
 name: Update pool
 on:
-  push:
+  # Skipping workflow execution on `push` events.
+  # push:
   schedule:
     - cron: '4 2 * * *' # daily at 2:04
 permissions:


### PR DESCRIPTION
We'll stick to executing that workflow on scheduled ("cron") events instead.