### PR TITLE
Misc linting fixes

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -19,6 +19,7 @@ import (
 func ExampleVerifyConnection() {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.TLSClientConfig = &tls.Config{
+		//nolint:gosec
 		// Set InsecureSkipVerify to skip the default validation we are
 		// replacing. This will not disable VerifyConnection.
 		InsecureSkipVerify: true,
@@ -30,6 +31,8 @@ func ExampleVerifyConnection() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer r.Body.Close()
+	defer func() {
+		_ = r.Body.Close()
+	}()
 	fmt.Println(r.StatusCode)
 }

--- a/intermediates.go
+++ b/intermediates.go
@@ -29,17 +29,17 @@ import (
 )
 
 //go:embed intermediates.bin
-var compressedPEMPool string
+var compressedPEMPool string //nolint:gochecknoglobals
 
-var _poolOnce sync.Once
-var _pool *x509.CertPool
+var _poolOnce sync.Once  //nolint:gochecknoglobals
+var _pool *x509.CertPool //nolint:gochecknoglobals
 
 func pool() *x509.CertPool {
 	_poolOnce.Do(func() {
 		r := flate.NewReader(strings.NewReader(compressedPEMPool))
 		pemList, _ := io.ReadAll(r)
 		_pool = x509.NewCertPool()
-		_pool.AppendCertsFromPEM([]byte(pemList))
+		_pool.AppendCertsFromPEM(pemList)
 	})
 	return _pool
 }

--- a/intermediates_test.go
+++ b/intermediates_test.go
@@ -14,17 +14,21 @@ import (
 func TestBadSSL(t *testing.T) {
 	t.Skip("badssl.com certificates are currently expired")
 	c, err := tls.Dial("tcp", "incomplete-chain.badssl.com:443", &tls.Config{
+		//nolint:gosec // skip default validation replaced by custom VerifyConnection function
 		InsecureSkipVerify: true,
 		VerifyConnection:   VerifyConnection,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 }
 
 func TestIncompleteChain(t *testing.T) {
 	c, err := tls.Dial("tcp", "google.com:443", &tls.Config{
+		//nolint:gosec // skip default validation replaced by custom VerifyConnection function
 		InsecureSkipVerify: true,
 		VerifyConnection: func(cs tls.ConnectionState) error {
 			cs.PeerCertificates = cs.PeerCertificates[:1]
@@ -34,7 +38,9 @@ func TestIncompleteChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 }
 
 func TestCount(t *testing.T) {


### PR DESCRIPTION
Resolve misc (admittedly nitpicky) linting errors.

Examples:

- Error return value of `c.Close` is not checked (errcheck)
- G402: TLS InsecureSkipVerify set true. (gosec)
- unnecessary conversion (unconvert)

Fixed by using nolint markers (gosec, where an existing custom verification function is already used) or applying minor changes.