### PR TITLE
Fix on-demand workflow event keyword

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,7 +4,7 @@ on:
   # push:
 
   # Permit manually triggering workflow for testing.
-  workflow_call:
+  workflow_dispatch:
 
   # This is the primary means of triggering this workflow.
   schedule:


### PR DESCRIPTION
Replace unintentional use of `workflow_call` event keyword with the intended `workflow_dispatch` keyword.

refs GH-1