### PR TITLE
Allow tags to trigger GH releases as intended

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  actions:  write # permit triggering other workflows
 
 jobs:
   git_describe_semver:


### PR DESCRIPTION
Apply additional permission to allow one workflow to trigger another. Due to the limited number of workflows that currently trigger on `push` events, this *should* be safe to enable.

refs GH-1
refs GH-4