### PR TITLE
Temporarily remove workflow restrictions

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,9 +19,12 @@ on:
     # * * * * *
     - cron: '4 2 * * *' # daily at 2:04
 
-permissions:
-  contents: write
-  actions:  write # permit triggering other workflows
+# Temporarily disable permission limits as part of troubleshooting failure
+# for this workflow to trigger execution of another workflow (release build).
+#
+#permissions:
+#  contents: write
+#  actions:  write # permit triggering other workflows
 
 jobs:
   git_describe_semver:


### PR DESCRIPTION
Comment out permissions limits allowing token to have full read and write permissions in the repository for all scopes.

The goal is to determine what changes are needed for this workflow to execute other workflows as part of automating new releases.