### PR TITLE
Update module path to reflect fork's path

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"time"
 
-	"filippo.io/intermediates"
+	"atc0005/intermediates"
 )
 
 func ExampleVerifyConnection() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module filippo.io/intermediates
+module atc0005/intermediates
 
 go 1.17


### PR DESCRIPTION
Replace original upstream module path with path of fork to allow `go get` and similar commands to work properly with fork.

fixes GH-35