### PR TITLE
Fix Go module path declaration to specify v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/atc0005/intermediates
+module github.com/atc0005/intermediates/v2
 
 go 1.17


### PR DESCRIPTION
Add missing `/v2` suffix to Go module path declaration to properly indicate that the module is now at the v2 release series.