### PR TITLE
Sort hashes before generating output files

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -662,6 +662,8 @@ func generateHashFile(inputCSVFile string, outputTXTFile string, csvColumns inte
 		hashes = append(hashes, record[csvColumns.Hash])
 	}
 
+	sort.Strings(hashes)
+
 	fh, err := os.Create(filepath.Clean(outputTXTFile))
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Sort hashes so that the diffs between automated releases are limited to actual content changes and not based on ordering changes in the input files (which has proven to be noisy).

- fixes GH-55