### PR TITLE
Update package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # atc0005/intermediates
 
 Package intermediates provides embedded hashes and intermediate certificates
-chaining to roots with Websites trust in the Mozilla Root Program.
+chaining to roots in the Mozilla Root Program.
 
 [![Latest Release](https://img.shields.io/github/release/atc0005/intermediates.svg?style=flat-square)](https://github.com/atc0005/intermediates/releases/latest)
 [![Go Reference](https://pkg.go.dev/badge/github.com/atc0005/intermediates.svg)](https://pkg.go.dev/github.com/atc0005/intermediates)

--- a/generate.go
+++ b/generate.go
@@ -8,9 +8,8 @@
 //go:build generate
 // +build generate
 
-// Tool used to generate intermediate certificates bundle from unexpired,
-// unrevoked intermediate certificates chaining to roots with Websites trust
-// in the Mozilla Root Program.
+// Tool used to generate intermediate certificate hashes and certificates
+// chaining to roots in the Mozilla Root Program.
 package main
 
 import (


### PR DESCRIPTION
Drop emphasis on sole purpose of package being to chain to roots with Websites trust as v2 of this package covers that purpose as well as providing revoked intermediate cert hashes and also the full collection of non-revoked intermediates.